### PR TITLE
Change include from arduino.h to Arduino.h to solve compilation in PlatformIO

### DIFF
--- a/src/RGBLED/RGBLED.h
+++ b/src/RGBLED/RGBLED.h
@@ -50,7 +50,7 @@ struct RGBLED{
     //Write to pins
     void Update(void) const{
         for(uint8_t i = 0; i < 3; i++){
-            analogWrite(led[i].pin, min((*led[i].value / 255 * PWMRANGE), PWMRANGE);
+            analogWrite(led[i].pin, min((*led[i].value / 255 * PWMRANGE), PWMRANGE));
         }
     }
 };

--- a/src/RGBLED/RGBLED.h
+++ b/src/RGBLED/RGBLED.h
@@ -50,7 +50,7 @@ struct RGBLED{
     //Write to pins
     void Update(void) const{
         for(uint8_t i = 0; i < 3; i++){
-            analogWrite(led[i].pin, *led[i].value);
+            analogWrite(led[i].pin, min((*led[i].value / 255 * PWMRANGE), PWMRANGE);
         }
     }
 };

--- a/src/RGBLEDBlender.h
+++ b/src/RGBLEDBlender.h
@@ -23,7 +23,7 @@
 #define RGBLEDBlender_h
 
 
-#include "arduino.h"
+#include "Arduino.h"
 #include "Color/Color.h"
 #include "RGBLED/RGBLED.h"
 #include "Colors/Colors.h"


### PR DESCRIPTION
I tried your library in my project but I got a warning in compilation because PlatformIO couldn't find arduino.h file. It was only a warning, but whenI tried the project with Gitlab CI/CD it just failed for the same reason. 
Just renaming the include from arduino.h to Arduino.h solves the issue (some OS or compiler are case-sensitive, but not all... )