### PR TITLE
fix integer division

### DIFF
--- a/src/RGBLED/RGBLED.h
+++ b/src/RGBLED/RGBLED.h
@@ -50,7 +50,7 @@ struct RGBLED{
     //Write to pins
     void Update(void) const{
         for(uint8_t i = 0; i < 3; i++){
-            analogWrite(led[i].pin, min((*led[i].value / 255 * PWMRANGE), PWMRANGE));
+            analogWrite(led[i].pin, min((*led[i].value * PWMRANGE / 255 ), PWMRANGE));
         }
     }
 };


### PR DESCRIPTION
in former core first is performed division which always leads to 0, because of int.
Swapping operations results in right value.