### PR TITLE
Fix filename case in #include directives

### DIFF
--- a/src/Color/Color.h
+++ b/src/Color/Color.h
@@ -23,7 +23,7 @@
 #define Color_h
 /*
 #if defined(ARDUINO) && ARDUINO >= 100
-#include "arduino.h"
+#include "Arduino.h"
 #else
 #include "WProgram.h"
 #endif*/


### PR DESCRIPTION
Incorrect capitalization of Arduino.h caused compilation to fail on filename case-sensitive operating systems like Linux.